### PR TITLE
bug in myagurim.js caused custom timestamps not to be parsed

### DIFF
--- a/cgi-bin/myagurim.cgi
+++ b/cgi-bin/myagurim.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/bin/python
 import common
 import subprocess
 import shlex

--- a/cgi-bin/myagurim.cgi
+++ b/cgi-bin/myagurim.cgi
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/python
 import common
 import subprocess
 import shlex

--- a/js/myagurim.js
+++ b/js/myagurim.js
@@ -1,6 +1,6 @@
 // configuration variables
 var cgi_path = "cgi-bin/";	// path to the cgi-bin directory
-var timeoffset = 9;		// time offset
+var timeoffset = 1;		// time offset
 // end of configuration variables
 
 var html = {
@@ -390,7 +390,7 @@ new function() {
 					query.duration = isNaN(val) ? 0 : val;
 				} else if (res[0] == "filter") {
 					query.filter = res[1];
-				} else if (res[0] == "startTime") {
+				} else if (res[0] == "startTimeStamp") {
 					if (String(res.slice(1))) {
 						var str = String(res.slice(1));
 						var res2 = str.split("T");
@@ -407,7 +407,7 @@ new function() {
 					} else {
 						query.startTime = 0;
 					}
-				} else if (res[0] == "endTime") {
+				} else if (res[0] == "endTimeStamp") {
 					if (String(res.slice(1))) {
 						var str = String(res.slice(1));
 						var res2 = str.split("T");

--- a/js/myagurim.js
+++ b/js/myagurim.js
@@ -1,6 +1,6 @@
 // configuration variables
 var cgi_path = "cgi-bin/";	// path to the cgi-bin directory
-var timeoffset = 1;		// time offset
+var timeoffset = 9;		// time offset
 // end of configuration variables
 
 var html = {


### PR DESCRIPTION
The input parser is looking for 'startTime', 'endTime' but the string coming in is 'startTimeStamp', even when the date provided to the details panel is in UTC format
