### PR TITLE
fix buffer overrun

### DIFF
--- a/src/agurim.c
+++ b/src/agurim.c
@@ -359,7 +359,7 @@ file_parse(char **files)
 	struct stat st;
 	FILE *fp;
         int i, m;
-	char file[254];
+	char file[NAME_MAX+1];
 
         if (stat(*files, &st) < 0) {
 #if 1
@@ -387,7 +387,7 @@ file_parse(char **files)
 			(void)fclose(fp);
                 }   
         } else  {
-		memcpy(file, *files, sizeof(file));
+		strncpy(file, *files, sizeof(file));
 		if ((fp = fopen(file, "r")) == NULL)
 			err(1, "can't open %s", file);
 		read_file(fp);


### PR DESCRIPTION
The call of memcpy() in agurim.c:file_parse() will cause a buffer
overrun bug.